### PR TITLE
Changes to header links and notice

### DIFF
--- a/index.css
+++ b/index.css
@@ -3,7 +3,7 @@ header {
     margin-top: 0;
     padding: 20px;
     font-size: 2rem;
-    text-align: left;
+    text-align: center;
     color: white;
     background: #002A3A;
 }
@@ -23,7 +23,7 @@ header a {
     display: inline-block;
     margin-top: 10px;
     padding: 10px 20px;
-    font-size: 1rem;
+    font-size: 2rem;
     background: white;
     text-decoration: none;
     color: #002A3A;
@@ -102,6 +102,7 @@ progress {
 /* ====== Notices ====== */
 .notice {
     color: red;
+    font-size: 1.5rem;
     font-weight: bold;
     text-align: center;
 }

--- a/pages/pages.css
+++ b/pages/pages.css
@@ -3,7 +3,7 @@ header {
     margin-top: 0;
     padding: 20px; /* reduce padding for mobile */
     font-size: 2rem; /* relative sizing */
-    text-align: left;
+    text-align: center;
     color: white;
     background: #002A3A;
 }
@@ -33,7 +33,7 @@ p {
 a {
     display: inline-block;
     padding: 10px 20px;
-    font-size: 1rem;
+    font-size: 2rem;
     background: white;
     text-decoration: none;
     color: #002A3A;


### PR DESCRIPTION
This PR:
- Makes the header links have the font-size of 2rem
- Center-aligns the header links
- Makes the `notice` CSS class slightly larger (1.5rem, as opposed to 1.0rem)